### PR TITLE
Fix deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "tools"
   ],
   "author": "Arnout Kazemier <opensource@observe.it>",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/observing/devnull.git"

--- a/transports/transport.js
+++ b/transports/transport.js
@@ -5,7 +5,7 @@
  * @copyright (c) 2013 Observe.it (http://observe.it) <opensource@observe.it>
  * MIT Licensed
  */
-var EventEmitter = process.EventEmitter;
+var EventEmitter = require('events').EventEmitter;
 
 /**
  * Strict type checking.


### PR DESCRIPTION
This patch makes `devnull` use the `events` module instead of `process.EventEmitter` because the latter has been deprecated in node 6.

This silences an annoying warning that is logged to the console when `devnull` is `require`d.