### PR TITLE
Bumped version number to allow packages to update.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devnull",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A simple logger with automatic function detection.",
   "homepage": "http://observe.it",
   "keywords": [


### PR DESCRIPTION
Addresses #5.
This allows people who depend on this package to update their dependency and receive the fix introduced in #4. This will mean a lot to people using Node version 7.x.x as they are currently unable to use this module.
